### PR TITLE
初デプロイ完了、ルートパスの定義

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
-  get "login" => "static_pages#top"
+  root "static_pages#top"
 end


### PR DESCRIPTION
初デプロイが完了しました。
デプロイした際、ルートパスが定義されていないためページが表示されないエラーが発生したため、ルートパスを定義しました。これにて初デプロイのissueを閉じます。

closes #19