### PR TITLE
プラン登録機能実装。加えて、スケジュール表に、登録したプランが表示されるようにビューファイルを修正

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,0 +1,27 @@
+class PlansController < ApplicationController
+  def new
+    @plan = Plan.new(starting_day_of_week: params[:starting_day_of_week].to_i, starting_time_before_type_conversion: params[:starting_time_before_type_conversion])
+  end
+
+  def create
+    @plan = Plan.new(plan_params)
+    @plan.starting_time = @plan.starting_time_before_type_conversion.strftime("%H:%M").to_s
+    @plan.ending_time = @plan.ending_time_before_type_conversion.strftime("%H:%M").to_s
+    if @plan.save
+      redirect_to schedule_path(@plan.schedule), notice: "#{@plan.name}を作成しました"
+    else
+      flash.now[:danger] = "プランを作成出来ませんでした"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @plan = Plan.find(params[:id])
+  end
+
+  private
+
+  def plan_params
+    params.require(:plan).permit(:name, :starting_day_of_week, :starting_time_before_type_conversion, :ending_day_of_week, :ending_time_before_type_conversion).merge(user_id: current_user.id, schedule_id: params[:schedule_id])
+  end
+end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,5 +1,6 @@
 class SchedulesController < ApplicationController
   before_action :time_define, only: %i[ new create show ]
+
   def index
     @schedules = current_user.schedules.all
   end
@@ -18,12 +19,14 @@ class SchedulesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @schedule = Schedule.find(params[:id])
+  end
 
   private
 
   def time_define
-    @time = Time.new(2026, 1, 5, 0, 0, 0, "+09:00")
+    @time = Time.new(2026, 1, 4, 0, 0, 0, "+00:00")
   end
 
   def schedule_params

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,0 +1,15 @@
+class Plan < ApplicationRecord
+  validates :name, presence: true
+  validates :starting_day_of_week, presence: true
+  validates :ending_day_of_week, presence: true
+  validates :starting_time, presence: true
+  validates :ending_time, presence: true
+
+  DAYS_OF_WEEK = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 }
+
+  enum starting_day_of_week: DAYS_OF_WEEK, _prefix: :starting
+  enum ending_day_of_week: DAYS_OF_WEEK, _prefix: :ending
+
+  belongs_to :user
+  belongs_to :schedule
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,4 +2,5 @@ class Schedule < ApplicationRecord
   validates :name, presence: true, length: { maximum: 32 }
 
   belongs_to :user
+  has_many :plans, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   has_many :schedules, dependent: :destroy
+  has_many :plans, dependent: :destroy
 end

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with model: plan, url: schedule_plans_path, method: :post do |f| %>
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+  <div class="field">
+    <%= f.label :starting_day_of_week %><br />
+    <%= f.select :starting_day_of_week, Plan.starting_day_of_weeks.keys.to_a, include_blank: "曜日" %>
+  </div>
+  <div class="field">
+    <%= f.label :starting_time %><br />
+    <%= f.time_select :starting_time_before_type_conversion, {minute_step: 30} %>
+  </div>
+  <div class="field">
+    <%= f.label :ending_day_of_week %><br />
+    <%= f.select :ending_day_of_week, Plan.ending_day_of_weeks.keys.to_a, include_blank: "曜日" %>
+  </div>
+  <div class="field">
+    <%= f.label :ending_time %><br />
+    <%= f.time_select :ending_time_before_type_conversion, {minute_step: 30} %>
+  </div>
+  <div class="actions">
+    <%= f.submit "作成" %>
+  </div>
+<% end %>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,0 +1,13 @@
+<h2>プラン作成</h2>
+<% if @plan.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(@plan.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+        <% @plan.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+<%= render "form", plan: @plan %>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: schedule, method: :post do |f| %>
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+  <div class="actions">
+    <%= f.submit "作成" %>
+  </div>
+<% end %>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -10,12 +10,4 @@
       </ul>
     </div>
   <% end %>
-<%= form_with model: @schedule, method: :post do |f| %>
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name %>
-  </div>
-  <div class="actions">
-    <%= f.submit "作成" %>
-  </div>
-<% end %>
+<%= render "form", schedule: @schedule %>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,5 +1,7 @@
 <%= link_to "管理画面に戻る", schedules_path %>
 
+<h2><%=  %></h2>
+
 <table>
   <thead>
     <th scope="col">時刻</th>
@@ -10,10 +12,16 @@
   <tbody>
     <% 48.times do |t| %>
       <tr>
-        <th scope="row"><%= "#{(@time + 60 * 30 * t).strftime("%H:%M")} ~ #{(@time + 60 * 30 * (t + 1)).strftime("%H:%M")}" %></th>
+      <% time_separate_start = @time + 60 * 30 * t %>
+      <% time_separate_end = @time + 60 * 30 * (t + 1) %>
+        <th scope="row"><%= "#{time_separate_start.strftime("%H:%M")} ~ #{time_separate_end.strftime("%H:%M")}" %></th>
         <% 7.times do |w| %>
           <td>
-            <%= link_to "+", "/" %>
+            <% if @schedule.plans.find_by(starting_day_of_week: w.to_i, starting_time_before_type_conversion: time_separate_start) %>
+              <%= @schedule.plans.find_by(starting_day_of_week: w.to_i, starting_time_before_type_conversion: time_separate_start).name %>
+            <% else %>
+              <%= link_to "+", new_schedule_plans_path(@schedule, starting_day_of_week: w.to_i, starting_time_before_type_conversion: time_separate_start) %>
+            <% end %>
           </td>
         <% end %>
       </tr>

--- a/app/views/shared_pages/_header.html.erb
+++ b/app/views/shared_pages/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="header" style="background-color:gray">
-  <p>ロゴ
+  <%= link_to "ロゴ", schedules_path %>
   <% if current_user %>
     <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,7 @@ Rails.application.routes.draw do
   post "login" => "user_sessions#create"
   get "logout" => "user_sessions#destroy", as: :logout
 
-  resources :schedules, only: %i[ index new create show ]
+  resources :schedules, only: %i[ index new create show ] do
+    resource :plans, only: %i[ new create show ], shallow: true
+  end
 end

--- a/db/migrate/20260111094209_create_plans.rb
+++ b/db/migrate/20260111094209_create_plans.rb
@@ -1,0 +1,17 @@
+class CreatePlans < ActiveRecord::Migration[7.2]
+  def change
+    create_table :plans do |t|
+      t.string :name, null: false
+      t.integer :starting_day_of_week, null: false
+      t.time :starting_time_before_type_conversion, null: false
+      t.string :starting_time, null: false
+      t.integer :ending_day_of_week, null: false
+      t.time :ending_time_before_type_conversion, null: false
+      t.string :ending_time, null: false
+      t.references :user, foreign_key: true
+      t.references :schedule, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_11_031657) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_11_094209) do
   create_table "action_mailbox_inbound_emails", charset: "utf8mb4", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -58,6 +58,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_11_031657) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "plans", charset: "utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "starting_day_of_week", null: false
+    t.time "starting_time_before_type_conversion", null: false
+    t.string "starting_time", null: false
+    t.integer "ending_day_of_week", null: false
+    t.time "ending_time_before_type_conversion", null: false
+    t.string "ending_time", null: false
+    t.bigint "user_id"
+    t.bigint "schedule_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["schedule_id"], name: "index_plans_on_schedule_id"
+    t.index ["user_id"], name: "index_plans_on_user_id"
+  end
+
   create_table "schedules", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.bigint "user_id"
@@ -78,5 +94,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_11_031657) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "plans", "schedules"
+  add_foreign_key "plans", "users"
   add_foreign_key "schedules", "users"
 end


### PR DESCRIPTION
プランの登録機能を実装しました。
スケジュール表に、登録したプランが表示されるようにしました。

スケジュールにプランを表示する方法については改善が必要です。本リリースで行います。現状ではSQLのクエリの発行回数がかなり多く、その分処理時間がかかるためです。MVPリリースでは表示されればOKとしているので、その分コードが雑になっているはずです。