### PR TITLE
プラン削除機能実装。

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -33,6 +33,14 @@ class PlansController < ApplicationController
     end
   end
 
+  def destroy
+    @plan = Plan.find_by(id: params[:id], schedule_id: params[:schedule_id])
+    return_pass = schedule_path(@plan.schedule)
+    plan_name = @plan.name
+    @plan.destroy
+    redirect_to return_pass, notice: "プラン「#{plan_name}」を削除しました"
+  end
+
   private
 
   def plan_params

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -24,3 +24,6 @@
   </div>
 <% end %>
 <%= link_to "戻る", :back %>
+<% if plan.id.present? %>
+  <%= button_to "削除", schedule_plan_path(plan.schedule, plan), method: :delete, data: { turbo_confirm: "削除しますか？" } %>
+<% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,6 +3,6 @@
 pin "application"
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.js"
-pin "@hotwired/turbo-rails", to: "@hotwired--turbo-rails.js" # @8.0.20
+pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/turbo", to: "@hotwired--turbo.js" # @8.0.20
 pin "@rails/actioncable/src", to: "@rails--actioncable--src.js" # @8.1.100

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,6 @@ Rails.application.routes.draw do
   get "logout" => "user_sessions#destroy", as: :logout
 
   resources :schedules, only: %i[ index new create show ] do
-    resources :plans, only: %i[ new create edit update ]
+    resources :plans, only: %i[ new create edit update destroy ]
   end
 end


### PR DESCRIPTION
プランの削除機能を実装しました。

Turboがうまく機能しておらず、link_toのdata: { turbo_method: :delete }が正常に動作せずbutton_toにしたり、data: { turbo_confirm: "削除しますか？" }のポップアップが表示されなかったりしております。

closes #16