### PR TITLE
Dockerfileの修正。1つ前のコミットで追加した「ENV TZ」の前行に「 \」を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -qq && \
 # Set production environment
 ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development:test"
+    BUNDLE_WITHOUT="development:test" \
     TZ="Asia/Tokyo"
 
 # Throw-away build stage to reduce size of final image


### PR DESCRIPTION
Dockerfileで、1つ前のコミットで追加した「ENV TZ」の前行に「 \」を追加しました。下記エラーが発生したためです。
```
error: failed to solve: dockerfile parse error on line 19: unknown instruction: TZ="Asia/Tokyo"
```