### PR TITLE
デプロイのビルド時にエラーが発生しないように、環境変数APP_HOSTにダミー値を入れる

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("APP_HOST"),
+    host: ENV.fetch("APP_HOST", "example.com"),
     protocol: "https"
   }
 


### PR DESCRIPTION
デプロイ時にキーAPP_HOSTが見つかりませんでしたというエラーが発生したため、ビルド時にエラーが発生しないように、環境変数APP_HOSTにダミー値を入れる