### PR TITLE
プラン登録機能改善+スケジュール表示方法改善の続き

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+
+  def time_define
+    @time = Time.new(2026, 2, 1, 0, 0, 0)
+  end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,9 +1,12 @@
 class PlansController < ApplicationController
   before_action :prohibit_interference_with_others, only: %i[ create edit update destroy ]
+  before_action :time_define, only: %i[ create update ]
   before_action :set_schedule
   before_action :set_plan, only: %i[ edit update destroy ]
   before_action :set_url_with_get_method, only: %i[ new create ]
   before_action :set_url_with_put_method, only: %i[ edit update ]
+
+  include DayOfWeek
 
   def new
     @plan = Plan.new(starting_day_of_week: params[:starting_day_of_week].to_i, starting_time_before_type_conversion: params[:starting_time_before_type_conversion])

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -37,7 +37,6 @@ class SchedulesController < ApplicationController
         add_to_plan_ids_hash(plan_hash, @plan_ids_hash, t)
       end
     end
-    binding.pry
   end
 
   def notifications
@@ -61,6 +60,7 @@ class SchedulesController < ApplicationController
   def time_slot_number_calculation(plan)
     ending_time = convert_time_to_seconds(get_date(plan.ending_day_of_week, plan.ending_time_before_type_conversion))
     starting_time = convert_time_to_seconds(get_date(plan.starting_day_of_week, plan.starting_time_before_type_conversion))
+    ending_time = ending_time + 7 * 24 * 60 * 60 if ending_time < starting_time
     (ending_time - starting_time) / (30 * 60)
   end
 

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -59,10 +59,8 @@ class SchedulesController < ApplicationController
   end
 
   def time_slot_number_calculation(plan)
-    end_con = convert_time_to_seconds(get_date(plan.ending_day_of_week, plan.ending_time_before_type_conversion))
-    start_con = convert_time_to_seconds(get_date(plan.starting_day_of_week, plan.starting_time_before_type_conversion))
-    ending_time = end_con + (plan.ending_day_of_week_before_type_cast - 1) * 24 * 60 * 60
-    starting_time = start_con + (plan.starting_day_of_week_before_type_cast - 1) * 24 * 60 * 60
+    ending_time = convert_time_to_seconds(get_date(plan.ending_day_of_week, plan.ending_time_before_type_conversion))
+    starting_time = convert_time_to_seconds(get_date(plan.starting_day_of_week, plan.starting_time_before_type_conversion))
     (ending_time - starting_time) / (30 * 60)
   end
 

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -47,10 +47,6 @@ class SchedulesController < ApplicationController
 
   private
 
-  def time_define
-    @time = Time.new(2026, 1, 4, 0, 0, 0)
-  end
-
   def schedule_params
     params.require(:schedule).permit(:name).merge(user_id: current_user.id)
   end
@@ -63,24 +59,34 @@ class SchedulesController < ApplicationController
   end
 
   def time_slot_number_calculation(plan)
-    end_con = convert_time_to_seconds(plan.ending_day_of_week_before_type_cast, plan.ending_time_before_type_conversion)
-    start_con = convert_time_to_seconds(plan.starting_day_of_week_before_type_cast, plan.starting_time_before_type_conversion)
-    ending_time = end_con + plan.ending_day_of_week_before_type_cast * 24 * 60 * 60
-    starting_time = start_con + plan.starting_day_of_week_before_type_cast * 24 * 60 * 60
-    binding.pry
+    end_con = convert_time_to_seconds(get_date(plan.ending_day_of_week, plan.ending_time_before_type_conversion))
+    start_con = convert_time_to_seconds(get_date(plan.starting_day_of_week, plan.starting_time_before_type_conversion))
+    ending_time = end_con + (plan.ending_day_of_week_before_type_cast - 1) * 24 * 60 * 60
+    starting_time = start_con + (plan.starting_day_of_week_before_type_cast - 1) * 24 * 60 * 60
     (ending_time - starting_time) / (30 * 60)
   end
 
   def add_to_plan_ids_hash(plan_hash, plan_ids_hash, t)
-    add_time_half_hour_each = plan_hash[1].starting_time_before_type_conversion + t * 30 * 60
-    plan_ids_hash[[ convert_time_to_seconds(DAYS_OF_WEEK[add_time_half_hour_each.strftime("%a")], add_time_half_hour_each) / (24 * 60 * 60), add_time_half_hour_each.strftime("%H:%M") ]] = plan_hash[1].id
+    # 下記のstarting_time_before_type_conversionを書き換える。get_dataを使用してこの予定の曜日を取得できるようにすること。
+    time = get_date(plan_hash[1].starting_day_of_week, plan_hash[1].starting_time_before_type_conversion)
+    add_time_half_hour_each = time + t * 30 * 60
+    plan_ids_hash[[ (convert_time_to_seconds(add_time_half_hour_each) / (24 * 60 * 60)).round, add_time_half_hour_each.strftime("%H:%M") ]] = plan_hash[1]
     # add_time_half_hour_eachの曜日を数字に変換して使いたいが、
     # add_time_half_hour_eachはデータベースに保存しない変数のため
     # starting_day_of_week_before_type_castで値を取得できない上にenumも使えない
     # enumで定義したものを他の変数にも使いたいが……
   end
 
-  def convert_time_to_seconds(day_of_week, time)
-    ((time.strftime("%k").to_i + day_of_week.to_i * 24) * 60 + time.strftime("%M").to_i) * 60
+  def convert_time_to_seconds(time)
+    ((time.strftime("%k").to_i + DAYS_OF_WEEK[time.strftime("%a")] * 24) * 60 + time.strftime("%M").to_i) * 60
+  end
+
+  def get_date(day_of_week, time)
+    Time.zone.local(@time.strftime("%Y").to_i,
+                    @time.strftime("%m").to_i,
+                    DAYS_OF_WEEK[day_of_week],
+                    time.strftime("%H").to_i,
+                    time.strftime("%M").to_i,
+                    0)
   end
 end

--- a/app/models/day_of_week.rb
+++ b/app/models/day_of_week.rb
@@ -1,4 +1,3 @@
 module DayOfWeek
   DAYS_OF_WEEK = { "Sun" => 1, "Mon" => 2, "Tue" => 3, "Wed" => 4, "Thu" => 5, "Fri" => 6, "Sat" => 7 }
 end
-

--- a/app/models/day_of_week.rb
+++ b/app/models/day_of_week.rb
@@ -1,3 +1,4 @@
 module DayOfWeek
-  DAYS_OF_WEEK = { "Sun" => 0, "Mon" => 1, "Tue" => 2, "Wed" => 3, "Thu" => 4, "Fri" => 5, "Sat" => 6 }
+  DAYS_OF_WEEK = { "Sun" => 1, "Mon" => 2, "Tue" => 3, "Wed" => 4, "Thu" => 5, "Fri" => 6, "Sat" => 7 }
 end
+

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -14,7 +14,7 @@ class Plan < ApplicationRecord
   belongs_to :schedule
 
   def self.current_day_of_week_value
-    current_day = Time.zone.now.strftime("%a").downcase.to_sym
+    current_day = Time.zone.now.strftime("%a")
     DAYS_OF_WEEK[current_day]
   end
 

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -23,7 +23,7 @@
           <td>
             <%= render partial: 'plan', locals: {
                                                   schedule: @schedule,
-                                                  w: w,
+                                                  w: w + 1,
                                                   time_separate_start: time_separate_start,
                                                   plans_hash: @plans_hash,
                                                   plan_ids_hash: @plan_ids_hash


### PR DESCRIPTION
1つ前のissueで解決しなかった問題の解決策として、プラン登録時のTimeクラスの値を取得する際、デフォルトの基準(2000年1月1日)ではなく、フォームで選択した曜日によって変化するように改善しました。これにより、使用する時間枠数の計算が楽かつ便利になりました。

また、スケジュール表示方法改善の続きとして、日を跨ぐプラン、週を跨ぐプランを正常に表示できるように修正しました。

closes #80